### PR TITLE
Bash scripts to generate and process sequencing reads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 __pycache__/
-data/
 models/
 !models/best_model.pth
 wandb/
 *.sh
+
+data/
+!data/*.sh

--- a/data/align_reads.sh
+++ b/data/align_reads.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+BWA="./bwa-0.7.17/bwa"
+
+VERBOSE=false
+while getopts r:q:o:v FLAG
+do
+  case "${FLAG}" in
+    r) REF=${OPTARG};;  # Path to reference genome
+    q) FASTQ=${OPTARG};;  # Path to FASTQ file
+    o) OUTPATH=${OPTARG};;  # Output file (full path or relative path)
+    v) VERBOSE=true;;
+    *) echo "$(basename $0): Invalid command line option: -$FLAG" ;;
+  esac
+done
+
+FNAME=$(basename $FASTQ)
+EXT="${FASTQ##*.}"
+FNAME=$(basename $FASTQ .$EXT)
+
+TMP="$FNAME"_filt.fq
+# Select reads that contain only A,C,G,T (N's are a bug in ART Illumina read generation)
+cat $FASTQ | awk '{
+        if (NR%4==1) {L1=$0} 
+        else if(NR%4==2) { if($0 ~ "^[ACGT][ACGT]+[ACGT]$") {L2=$0} else {L2="invalid"} }  
+        else if(NR%4==3) {L3=$0} 
+        else { if(L2!="invalid") {print L1"\n"L2"\n"L3"\n"$0} }
+        }' > $TMP
+
+# $BWA index $REF
+$BWA mem -t 5 $REF $TMP | samtools view -F 4 > $OUTPATH 2> /dev/null  # Align and remove unmapped reads
+
+OUTNAME=$(basename $OUTPATH ".sam")
+awk '{print $1" "$4}' $OUTPATH > $OUTNAME"_pos.txt"  # Save read names and positions

--- a/data/comp_stats.sh
+++ b/data/comp_stats.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Script to count the lengths of genomes for each class (human/virus).
+
+TMP="tmp"
+
+# Statistics for human class
+: <<'HUMAN'
+grep -v '^>' references/GRCh38.fa > $TMP
+NUMN=$(awk -v RS='N' 'END{print NR-1}' $TMP)  # Number of N's
+echo "Number of N's in human genome: $NUMN"
+NUMC=$(wc $TMP | awk '{print $3-$1}')  # Number of characters
+echo "Length of human genome: $NUMC"
+echo "True length of human genome: $((NUMC-NUMN))"
+
+READS=$(grep '^@NC' human_reads_filt.fq | wc -l)  # Number of reads
+echo "Number of human reads: $READS"
+HUMAN
+
+# Statistics for viral class
+CLASS="MCV"
+echo "Statistics for $CLASS"
+GENOMES=$(grep "^>"$CLASS references/viral_genomes.fa | wc -l)
+echo "Number of genomes: $GENOMES"
+
+cat references/viral_genomes.fa | awk -v var="$CLASS" '{
+        if (NR%2==1) { if($0 ~ "^>"var) {L1="valid"} else {L1="invalid"} }
+        else { if(L1!="invalid") { print $0 } }
+        }' > $TMP
+
+NUMC=$(wc $TMP | awk '{print $3-$1}')  # Number of characters
+echo "Total length of viral genomes: $NUMC"
+
+READS=$(grep "^@"$CLASS viral_reads_filt.fq | wc -l)  # Number of reads
+echo "Number of viral reads: $READS"
+
+rm $TMP

--- a/data/concat_genomes.sh
+++ b/data/concat_genomes.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Concatenate all the viral genomes in the iCAV folder
+# Processing appends the folder name to the header to enable tracking of the source of the genome
+
+# Assumed directory structure
+# -concat_genomes.fa (current script)
+# -iCAV_all_data
+#   --virus1
+#     ---virus1_genomes.fasta
+#   --virus2
+#     ---virus2_genomes.fasta
+
+ICAV="iCAV_all_data"  # Path to unzipped iCAV data folder
+OUT="viral_genomes.fa"  # Output file
+
+for VDIR in "$ICAV"/* ; do 
+  if [ -d $VDIR ]; then
+    echo $VDIR
+    VIR=$(basename $VDIR)
+    for FASTA in "$VDIR"/*".fasta" ; do
+      if [ -f $FASTA ]; then
+        echo $FASTA
+        cat $FASTA | awk -v var="$VIR" '{if ($0 ~ /^>/) {print ">"var"_"substr($0,2) } else {print $0}}' > $OUT
+      fi
+    done
+  fi
+done

--- a/data/gen_reads.sh
+++ b/data/gen_reads.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+ART="art_bin_MountRainier/art_illumina"
+
+VERBOSE=false
+while getopts f:o:n:v FLAG
+do
+  case "${FLAG}" in
+    f) REF=${OPTARG};;  # Path to reference genome
+    o) OUTPATH=${OPTARG};;  # Output file (full path or relative path)
+    n) READCNT=${OPTARG};;  # Number of reads to be generated
+    v) VERBOSE=true;;
+    *) echo "$(basename $0): Invalid command line option: -$FLAG" ;;
+  esac
+done
+
+if ! [[ -d $(dirname $OUTPATH) ]];then
+  mkdir $(dirname $OUTPATH)
+fi
+
+
+NUM_GENOME=$(grep -o '>' $REF | wc -l)
+RCNT=`expr $READCNT / $NUM_GENOME`
+# echo $READCNT
+# echo $NUM_GENOME
+echo $RCNT
+# $ART -na -q -i $REF -l 150 --seqSys HS25 --rcount $RCNT -o $OUTPATH
+$ART -na -q -i $REF -l 150 --seqSys MSv3 --rcount $RCNT -o $OUTPATH -nf 1


### PR DESCRIPTION
This PR includes several Shell scripts in the `data` directory.

-  `concat_genomes.sh` : Concatenate viral genomes from the source directory.
- `gen_reads.sh`: Simulate MiSeq sequencing reads from the given genomes.
- `align_reads.sh`: Align reads to reference genome(s).
- `comp_stats.sh`: Compute sequencing read statistics by class.